### PR TITLE
Put feedstock in anacondarecipes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto
+
+meta.yaml text eol=lf

--- a/README.md
+++ b/README.md
@@ -8,3 +8,4 @@ Package license: [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 Feedstock license: [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
 Summary: Linter for conda feedstocks
+

--- a/README.md
+++ b/README.md
@@ -8,4 +8,3 @@ Package license: [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 Feedstock license: [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
 Summary: Linter for conda feedstocks
-

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-# anaconda-linter-feedstock
+About anaconda-linter
+=====================
+
+Home: https://github.com/anaconda-distribution/anaconda-linter
+
+Package license: [BSD-3-Clause](https://github.com/conda-forge/onnxruntime-feedstock/blob/main/LICENSE.txt)
+
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/onnxruntime-feedstock/blob/main/LICENSE.txt)
+
+Summary: Linter for conda feedstocks

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ About anaconda-linter
 
 Home: https://github.com/anaconda-distribution/anaconda-linter
 
-Package license: [BSD-3-Clause](https://github.com/conda-forge/onnxruntime-feedstock/blob/main/LICENSE.txt)
+Package license: [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/onnxruntime-feedstock/blob/main/LICENSE.txt)
+Feedstock license: [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
 Summary: Linter for conda feedstocks

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,3 +41,16 @@ test:
     - pytest-html
   commands:
     - python -m pytest -vv tests
+
+about:
+  home: https://github.com/anaconda-distribution/anaconda-linter
+  license: BSD-3-Clause
+  license_family: BSD
+  license_file: LICENSE
+  license_url: https://opensource.org/licenses/BSD-3-Clause
+  summary: A conda feedstock linter written in pure Python.
+  description: |
+    Runs a range of static checks on conda feedstocks. Under
+    ongoing development. 
+  doc_url: https://github.com/anaconda-distribution/anaconda-linter/blob/main/README.md
+  dev_url: https://github.com/anaconda-distribution/anaconda-linter 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,8 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
+  entry_points:
+    - conda-lint = anaconda_linter.run:main
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 source:
-  git_url: https://github.com/anaconda-distribution/anaconda-linter.git
+  git_url: git@github.com:anaconda-distribution/anaconda-linter.git
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,7 +5,9 @@ package:
   version: {{ version }}
 
 source:
-  git_url: git@github.com:anaconda-distribution/anaconda-linter.git
+  fn: anaconda-linter-{{ version }}.tar.gz
+  url: https://github.com/anaconda-distribution/anaconda-linter/archive/{{ version }}.tar.gz
+  sha256: c0004740a8ca22041ca284e486d228c12577bc4f51de4f2e5f4b36509dec4764
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,32 @@
+package:
+  name: anaconda-linter
+  version: 0.0.1
+source:
+  git_url: ../
+build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
+requirements:
+  host:
+    - python
+    - pip
+    - setuptools
+  run:
+    - python
+    - ruamel.yaml
+    - pyyaml
+    - license-expression
+    - jinja2
+    - tqdm
+    - conda-build
+    - jsonschema
+    - networkx
+test:
+  source_files:
+    - tests
+  requires:
+    - pytest
+    - pytest-cov
+    - pytest-html
+  commands:
+    - python -m pytest -vv tests

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
 
 build:
   number: 0
+  skip: True  # [py<38]
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
   entry_points:
     - conda-lint = anaconda_linter.run:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,11 +1,16 @@
+{% set version = "0.0.1" %}
+
 package:
   name: anaconda-linter
-  version: 0.0.1
+  version: {{ version }}
+
 source:
-  git_url: ../
+  git_url: https://github.com/anaconda-distribution/anaconda-linter.git
+
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
+
 requirements:
   host:
     - python
@@ -21,6 +26,7 @@ requirements:
     - conda-build
     - jsonschema
     - networkx
+
 test:
   source_files:
     - tests


### PR DESCRIPTION
See related PR to remove the feedstock from the code directory [here](https://github.com/anaconda-distribution/anaconda-linter/pull/81)

This fixes building (since conda build no longer cares about the `meta.yaml`s in the `tests/` directory)