### PR TITLE
Patch to prohibit license_family: None

### DIFF
--- a/recipe/0001-prohibit-license-family-none.patch
+++ b/recipe/0001-prohibit-license-family-none.patch
@@ -1,0 +1,65 @@
+diff --git a/anaconda_linter/lint/check_completeness.py b/anaconda_linter/lint/check_completeness.py
+index 1be7be4..aec0abf 100644
+--- a/anaconda_linter/lint/check_completeness.py
++++ b/anaconda_linter/lint/check_completeness.py
+@@ -150,7 +150,7 @@ class missing_license_family(LintCheck):
+ 
+ 
+ class invalid_license_family(LintCheck):
+-    """The recipe has an incorrect ``about/license_family`` value.
++    """The recipe has an incorrect ``about/license_family`` value.{}
+ 
+     Please change::
+ 
+@@ -160,11 +160,18 @@ class invalid_license_family(LintCheck):
+     """
+ 
+     def check_recipe(self, recipe):
+-        license_family = recipe.get("about/license_family", "")
+-        if license_family and not license_family.lower() in [
+-            x.lower() for x in conda_build.license_family.allowed_license_families
+-        ]:
+-            self.message(section="about")
++        license_family = recipe.get("about/license_family", "").lower()
++        if license_family:
++            if license_family == "none":
++                msg = (
++                    " Using 'None' breaks some uploaders."
++                    " Use skip-lint to skip this check instead."
++                )
++                self.message(msg, section="about")
++            elif license_family not in [
++                x.lower() for x in conda_build.license_family.allowed_license_families
++            ]:
++                self.message(section="about")
+ 
+ 
+ class missing_tests(LintCheck):
+diff --git a/tests/test_completeness.py b/tests/test_completeness.py
+index e5abfb0..52b2912 100644
+--- a/tests/test_completeness.py
++++ b/tests/test_completeness.py
+@@ -222,6 +222,23 @@ def test_invalid_license_family(base_yaml):
+     assert len(messages) == 1 and "about/license_family` value" in messages[0].title
+ 
+ 
++def test_invalid_license_family_none(base_yaml):
++    yaml_str = (
++        base_yaml
++        + """
++        about:
++          license_family: None
++        """
++    )
++    lint_check = "invalid_license_family"
++    messages = check(lint_check, yaml_str)
++    assert (
++        len(messages) == 1
++        and "about/license_family` value" in messages[0].title
++        and "Using 'None' breaks" in messages[0].title
++    )
++
++
+ def test_missing_tests_good_import(base_yaml):
+     yaml_str = (
+         base_yaml

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,15 +8,21 @@ source:
   fn: anaconda-linter-{{ version }}.tar.gz
   url: https://github.com/anaconda-distribution/anaconda-linter/archive/{{ version }}.tar.gz
   sha256: 157e7a28a81a56c871c420af674bc83bf21039637511a134e9059e7e99d47760
+  patches:
+    # https://github.com/anaconda-distribution/anaconda-linter/pull/226
+    - 0001-prohibit-license-family-none.patch
 
 build:
-  number: 0
+  number: 1
   skip: True  # [py<38]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv
   entry_points:
     - conda-lint = anaconda_linter.run:main
 
 requirements:
+  build:
+    - patch  # [not win]
+    - m2-patch  # [win]
   host:
     - python
     - pip


### PR DESCRIPTION
Using "None" as a value for license_family breaks some of our uploaders. Until this is fixed, the linter should prohibit the use of "None" as the license family.

See the following linter PR: https://github.com/anaconda-distribution/anaconda-linter/pull/226