### PR TITLE
v0.1.3 update

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 source:
   fn: anaconda-linter-{{ version }}.tar.gz
   url: https://github.com/anaconda-distribution/anaconda-linter/archive/{{ version }}.tar.gz
-  sha256: a4ccf8064a39b422f7862a9989aa1b766d0e5257fab96dbd490c9a3cc0e55be9
+  sha256: 81e96fd246496b653cf7eff0d2e87e488c176e3be870d51fee8d23b4a3386efb
 
 build:
   number: 0
@@ -24,7 +24,7 @@ requirements:
     - setuptools
     - wheel
   run:
-    - python
+    - python >=3.11
     - requests
     - ruamel.yaml
     - license-expression
@@ -32,7 +32,7 @@ requirements:
     - conda-build
     - jsonschema
     - networkx
-    - percy >=0.1.1,<0.2.0
+    - percy >=0.1.3
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,8 +11,8 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<39]
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv
+  noarch: python
+  script: pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - conda-lint = anaconda_linter.run:main
     - anaconda-lint = anaconda_linter.run:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.1.2" %}
+{% set version = "0.1.3" %}
 
 package:
   name: anaconda-linter
@@ -7,10 +7,10 @@ package:
 source:
   fn: anaconda-linter-{{ version }}.tar.gz
   url: https://github.com/anaconda-distribution/anaconda-linter/archive/{{ version }}.tar.gz
-  sha256: b42afa8558fc4e06fa8a216bf5952bf5ce15d688c871748787746d3d28727a25
+  sha256: a4ccf8064a39b422f7862a9989aa1b766d0e5257fab96dbd490c9a3cc0e55be9
 
 build:
-  number: 2
+  number: 0
   skip: True  # [py<39]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vvv
   entry_points:
@@ -29,7 +29,7 @@ requirements:
     - ruamel.yaml
     - license-expression
     - jinja2
-    - conda-build <3.28.0  # Pinned to resolve bug in conda-build 3.28.0
+    - conda-build
     - jsonschema
     - networkx
     - percy >=0.1.1,<0.2.0


### PR DESCRIPTION
This PR is on-hold/should not be merged UNTIL we have confirmation that our internal infrastructure has been deployed.

This PR is just sitting pretty until we are ready to hit the big green button.

Release: https://github.com/anaconda-distribution/anaconda-linter/releases/tag/0.1.3