### PR TITLE
update to 0.1.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.1.3" %}
+{% set version = "0.1.4" %}
 
 package:
   name: anaconda-linter
@@ -7,7 +7,7 @@ package:
 source:
   fn: anaconda-linter-{{ version }}.tar.gz
   url: https://github.com/anaconda-distribution/anaconda-linter/archive/{{ version }}.tar.gz
-  sha256: 81e96fd246496b653cf7eff0d2e87e488c176e3be870d51fee8d23b4a3386efb
+  sha256: 0d451ff55003ad168c7722748ac4b89f4a920bc02aa2b8a4406d06df10fe2b47
 
 build:
   number: 0


### PR DESCRIPTION
anaconda-linter 0.1.4

**Destination channel:** distro-tooling

https://github.com/anaconda/anaconda-linter/blob/0.1.4/CHANGELOG.md